### PR TITLE
correct fromNow variable assignment

### DIFF
--- a/perf/dom-react-vs-vanilla/src/app.js
+++ b/perf/dom-react-vs-vanilla/src/app.js
@@ -35,7 +35,7 @@ var FlickrImage = React.createClass({
   render: function() {
 
     // Figure out how long ago this photo was taken.
-    var fromNow = moment(this.props.image.lastUpdated).fromNow();
+    var fromNow = moment.unix(this.props.image.lastUpdate).fromNow();
 
     // Render away!
     return (


### PR DESCRIPTION
I've corrected the `lastUpdate` property from `this.props.image` from the incorrect key of `lastUpdated`

I've also corrected the use of the `moment` api. Since `this.props.image.lastUpdate` is epoch time, you have to invoke `moment.unix()` on it.